### PR TITLE
fix: checkov and tflint

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -15,7 +15,7 @@ module "vpc_dev" {
 #                     VM
 ########################################################
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=1.0.0"
   env_name        = "develop"
   network_id      = module.vpc_dev.vpc_id
   subnet_zones    = ["ru-central1-a"]
@@ -23,8 +23,10 @@ module "test-vm" {
   instance_name   = "web"
   instance_count  = 1
   image_family    = "ubuntu-2004-lts"
-  public_ip       = true
-  
+  public_ip       = false
+  security_group_ids = [yandex_vpc_security_group.example.id]
+
+
   metadata = {
       user-data          = data.template_file.cloudinit.rendered
       serial-port-enable = 1

--- a/src/modules/vpc/providers.tf
+++ b/src/modules/vpc/providers.tf
@@ -3,8 +3,9 @@ terraform {
     yandex = {
       source = "yandex-cloud/yandex"
     }
+    template = "~> 2.0"
   }
-  required_version = ">=0.13"
+  required_version = ">=0.13.0"
 }
 
 provider "yandex" {

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -2,9 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~> 0.9"
     }
+    template  = "~> 2.0"
   }
-  required_version = ">=0.13"
+  required_version = ">= 0.13"
 
   backend "s3" {
     endpoint = "storage.yandexcloud.net"

--- a/src/security.tf
+++ b/src/security.tf
@@ -1,0 +1,86 @@
+variable "security_group_ingress" {
+  description = "secrules ingress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий ssh"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 22
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий  http"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 80
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий https"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 443
+    },
+  ]
+}
+
+
+variable "security_group_egress" {
+  description = "secrules egress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    { 
+      protocol       = "TCP"
+      description    = "разрешить весь исходящий трафик"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      from_port      = 0
+      to_port        = 65365
+    }
+  ]
+}
+
+
+resource "yandex_vpc_security_group" "example" {
+  name       = "example_dynamic"
+  network_id = module.vpc_dev.vpc_id
+  folder_id  = var.folder_id
+
+  dynamic "ingress" {
+    for_each = var.security_group_ingress
+    content {
+      protocol       = lookup(ingress.value, "protocol", null)
+      description    = lookup(ingress.value, "description", null)
+      port           = lookup(ingress.value, "port", null)
+      from_port      = lookup(ingress.value, "from_port", null)
+      to_port        = lookup(ingress.value, "to_port", null)
+      v4_cidr_blocks = lookup(ingress.value, "v4_cidr_blocks", null)
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.security_group_egress
+    content {
+      protocol       = lookup(egress.value, "protocol", null)
+      description    = lookup(egress.value, "description", null)
+      port           = lookup(egress.value, "port", null)
+      from_port      = lookup(egress.value, "from_port", null)
+      to_port        = lookup(egress.value, "to_port", null)
+      v4_cidr_blocks = lookup(egress.value, "v4_cidr_blocks", null)
+    }
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -20,28 +20,6 @@ variable "default_zone" {
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
 
-###common vars
-
-variable "vms_ssh_root_key" {
-  type        = string
-  default     = "your_ssh_ed25519_key"
-  description = "ssh-keygen -t ed25519"
-}
-
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
-
 
 ### Cloud init variables
 variable "cloud_init_packages" {


### PR DESCRIPTION
--------------------------------------------------------------------------------
                                               CHEKOV
--------------------------------------------------------------------------------

andy@ubu18:~/netology/git$ checkov --download-external-modules true --directory ./devops-netology
[ kubernetes framework ]: 100%|████████████████████|[2/2], Current File Scanned=src/docker-compose.yml
[ secrets framework ]: 100%|████████████████████|[12/12], Current File Scanned=./devops-netology/src/modules/vpc/output.tf   
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=src/cloud-init.yml
[ terraform framework ]: 100%|████████████████████|[12/12], Current File Scanned=src/variables.tf                                                              


       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.3.281 
Update available 2.3.281 -> 2.3.283
Run pip3 install -U checkov to update 


terraform scan results:

Passed checks: 4, Failed checks: 0, Skipped checks: 0

Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.test-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/1.0.0/main.tf:24-73
        Calling File: /src/main.tf:17-35
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.test-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/1.0.0/main.tf:24-73
        Calling File: /src/main.tf:17-35
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.test-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/1.0.0/main.tf:24-73
        Calling File: /src/main.tf:17-35
Check: CKV_YC_19: "Ensure security group does not contain allow-all rules."
        PASSED for resource: yandex_vpc_security_group.example
        File: /src/security.tf:58-86

--------------------------------------------------------------------------------
                                               TFLINT
--------------------------------------------------------------------------------
andy@ubu18:~/netology/git$ tflint --chdir ./devops-netology/src/
<EMPTY>

--------------------------------------------------------------------------------
                                      TERRAFORM PLAN
--------------------------------------------------------------------------------
andy@ubu18:~/netology/git/devops-netology/src$ tf plan
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=a649e5a8f9ce936e76bd762ece7ed1544000035ebb59ea23ab2e0bdd6806b242]
module.test-vm.data.yandex_compute_image.my_image: Reading...
module.test-vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd83vhe8fsr4pe98v6oj]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # yandex_vpc_security_group.example will be created
  + resource "yandex_vpc_security_group" "example" {
      + created_at = (known after apply)
      + folder_id  = "b1gnfh9j71rchj9q61gr"
      + id         = (known after apply)
      + labels     = (known after apply)
      + name       = "example_dynamic"
      + network_id = (known after apply)
      + status     = (known after apply)

      + egress {
          + description    = "разрешить весь исходящий трафик"
          + from_port      = 0
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = -1
          + protocol       = "TCP"
          + to_port        = 65365
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }

      + ingress {
          + description    = "разрешить входящий  http"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 80
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
      + ingress {
          + description    = "разрешить входящий https"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 443
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
      + ingress {
          + description    = "разрешить входящий ssh"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 22
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "develop-web-0"
      + id                        = (known after apply)
      + labels                    = {
          + "env"     = "develop"
          + "project" = "undefined"
        }
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDAS/kWObfpfsLnbryR+CUgHP+J5hRf2/jbmLCEm9iBpcM2d0hDWQ1BL2wOK05KRk7khbFquvEG2HUQsigfckH9gHUTZ6m/h5RoZciGvF1Pi/L40u4uVD2uidMk8ILWzM1sfFGngWh+j2QBebNYxZ9bCTtjYq50pEl9NZRGyYn6wSBAuoctN/chROoHTL4hZwW5ap2GCmpr7JMsaQ5WXRnOZvzG9ISOsRGh7bPjIu1zM50ch5edNva0bRZmzq49iz8MP7QDQWUlODQtQIoo5AMGM9s/4nGWkzXvosGFIMRrD3mxKhUH/0gF1P6MIrxT+cAEvinqYmy9JtOuQeKxej5aVAWwHiSuYpGViG70aQr4CjjwLQQARvUZvHMPic89QUBzxDbU2FILGh1NwiNDsWwnNmpF3EJvPHmPdd0AyFSayc63FgoyJocnu41wgMol472+zPyKECqgH0cd/d20SHrqZUL+MnQAqkRcnQjWM6OQEE/19l1eo34GstH29hBxg8779Z5fkVRo1rakuI03p0V9gGULNIwnAS2VviCyVD6o0fR5+8lwHVGdKZ7tGSeGNKObLNxuAdkURkwwchry4m0Le3Gx039rv861nnhG1TKdP29aLW1pl2sKKmenD0iRz9EaoKwdebvJeVaI1oO3ku6Ms6r00AI6pJ297P/ytfBdYQ== andy@ubu18
                
                package_update: true
                package_upgrade: false
                packages: ["vim","nginx"]
            EOT
        }
      + name                      = "develop-web-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd83vhe8fsr4pe98v6oj"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = false
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vpc_dev.yandex_vpc_network.vpc_network will be created
  + resource "yandex_vpc_network" "vpc_network" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # module.vpc_dev.yandex_vpc_subnet.vpc_subnet will be created
  + resource "yandex_vpc_subnet" "vpc_subnet" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

Plan: 4 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...